### PR TITLE
d2x-v10-beta52-vWii

### DIFF
--- a/_pages/en_US/vwii-modding.txt
+++ b/_pages/en_US/vwii-modding.txt
@@ -69,19 +69,19 @@ Ensure that there are no folders named `wad` or `wads` on the root of your SD ca
   + CBHC Mocha CFW users can do this by holding (B) at boot, then selecting "Boot vWii Homebrew Channel"
 1. Launch d2x cIOS Installer
 1. Set the options on the top of the screen to match the following:
-  + Select cIOS : **d2x-v10-beta53-alt-vWii**
+  + Select cIOS : **d2x-v10-beta52-vWii**
   + Select cIOS base : **56**
   + Select cIOS slot : **249**
 1. Press (A) to install
 1. Wait for the install to complete, then press (A) to continue
 1. Set the options on the top of the screen to match the following:
-  + Select cIOS : **d2x-v10-beta53-alt-vWii**
+  + Select cIOS : **d2x-v10-beta52-vWii**
   + Select cIOS base : **57**
   + Select cIOS slot : **250**
 1. Press (A) to install
 1. Wait for the install to complete, then press (A) to continue
 1. Set the options on the top of the screen to match the following:
-  + Select cIOS : **d2x-v10-beta53-alt-vWii**
+  + Select cIOS : **d2x-v10-beta52-vWii**
   + Select cIOS base : **58**
   + Select cIOS slot : **251**
 1. Press (A) to install


### PR DESCRIPTION
Switching to beta52 since theres no real benefit from using beta53, since beta53 breaks loading backups from the sd card.
Information from: https://flumpster.lolcakes.com/cios.html