### PR TITLE
Link the latest release of hid_to_vpad instead of the latest nightly …

### DIFF
--- a/_pages/af_ZA/get-started.txt
+++ b/_pages/af_ZA/get-started.txt
@@ -28,7 +28,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/ar_SA/get-started.txt
+++ b/_pages/ar_SA/get-started.txt
@@ -28,7 +28,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/ca_ES/get-started.txt
+++ b/_pages/ca_ES/get-started.txt
@@ -28,7 +28,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/cs_CZ/get-started.txt
+++ b/_pages/cs_CZ/get-started.txt
@@ -28,7 +28,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/da_DK/get-started.txt
+++ b/_pages/da_DK/get-started.txt
@@ -28,7 +28,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/de_DE/get-started.txt
+++ b/_pages/de_DE/get-started.txt
@@ -28,7 +28,7 @@ Bevor du anfängst, solltest du deine SD-Karte auf Fehler überprüfen. Verwende
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/el_GR/get-started.txt
+++ b/_pages/el_GR/get-started.txt
@@ -28,7 +28,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/en_PT/get-started.txt
+++ b/_pages/en_PT/get-started.txt
@@ -28,7 +28,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/en_US/get-started.txt
+++ b/_pages/en_US/get-started.txt
@@ -28,7 +28,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/es_ES/get-started.txt
+++ b/_pages/es_ES/get-started.txt
@@ -28,7 +28,7 @@ Tu tarjeta SD *no puede* llamarse `wiiu`, o causará problemas.
 * La última versión de [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * La última versión de [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * La última versión de [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* La última versión de [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* La última versión de [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * La última versión de [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * La última versión de [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * La última versión del [Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(el archivo `.zip` que dice "channel")*

--- a/_pages/fi_FI/get-started.txt
+++ b/_pages/fi_FI/get-started.txt
@@ -28,7 +28,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/fr_FR/get-started.txt
+++ b/_pages/fr_FR/get-started.txt
@@ -28,7 +28,7 @@ Avant de commencer, il serait de bonne garde de vérifier l'intégrité de votre
 * La dernière version de [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 La dernière version de [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * La dernière version de [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* La dernière version de [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* La dernière version de [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * La dernière version de [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * La dernière version de [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * La dernière version de [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(le fichier `.zip` de la chaîne)*

--- a/_pages/he_IL/get-started.txt
+++ b/_pages/he_IL/get-started.txt
@@ -28,7 +28,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/hu_HU/get-started.txt
+++ b/_pages/hu_HU/get-started.txt
@@ -28,7 +28,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/id_ID/get-started.txt
+++ b/_pages/id_ID/get-started.txt
@@ -28,7 +28,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/it_IT/get-started.txt
+++ b/_pages/it_IT/get-started.txt
@@ -28,7 +28,7 @@ Prima di iniziare è consigliabile verificare che la tua scheda SD sia priva di 
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/ja_JP/get-started.txt
+++ b/_pages/ja_JP/get-started.txt
@@ -28,7 +28,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/ko_KR/get-started.txt
+++ b/_pages/ko_KR/get-started.txt
@@ -28,7 +28,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/ms_MY/get-started.txt
+++ b/_pages/ms_MY/get-started.txt
@@ -28,7 +28,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/nl_NL/get-started.txt
+++ b/_pages/nl_NL/get-started.txt
@@ -28,7 +28,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/no_NO/get-started.txt
+++ b/_pages/no_NO/get-started.txt
@@ -28,7 +28,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/pl_PL/get-started.txt
+++ b/_pages/pl_PL/get-started.txt
@@ -28,7 +28,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/pt_BR/get-started.txt
+++ b/_pages/pt_BR/get-started.txt
@@ -28,7 +28,7 @@ Antes de iniciar, você pode querer verificar se o seu cartão SD possui erros u
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/pt_PT/get-started.txt
+++ b/_pages/pt_PT/get-started.txt
@@ -28,7 +28,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/ro_RO/get-started.txt
+++ b/_pages/ro_RO/get-started.txt
@@ -28,7 +28,7 @@ Cardul SD * nu poate * fi numit 'wiiu', sau va provoca probleme.
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/ru_RU/get-started.txt
+++ b/_pages/ru_RU/get-started.txt
@@ -28,7 +28,7 @@ SD-карта должна быть отформатирована в FAT32 (р�
 * Свежая версия [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * Свежая версия [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * Свежая версия [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* Свежая версия [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* Свежая версия [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * Свежая версия [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * Свежая версия [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * Свежая версия [Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(`.zip-архив` с суффиксом _channel)*

--- a/_pages/sr_SP/get-started.txt
+++ b/_pages/sr_SP/get-started.txt
@@ -28,7 +28,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/sv_SE/get-started.txt
+++ b/_pages/sv_SE/get-started.txt
@@ -28,7 +28,7 @@ Innan du börjar rekommenderas du att säkerställa integriteten på ditt SD-kor
 * Senaste versionen av [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * Senaste versionen av [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * Senaste versionen av [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* Senaste versionen av [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* Senaste versionen av [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * Senaste versionen av [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * Senaste versionen av [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * Senaste versionen av [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(`.zip`-filen som har `channel` i fil-namnet)*

--- a/_pages/th_TH/get-started.txt
+++ b/_pages/th_TH/get-started.txt
@@ -28,7 +28,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/tr_TR/get-started.txt
+++ b/_pages/tr_TR/get-started.txt
@@ -28,7 +28,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/uk_UA/get-started.txt
+++ b/_pages/uk_UA/get-started.txt
@@ -28,7 +28,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/vi_VN/get-started.txt
+++ b/_pages/vi_VN/get-started.txt
@@ -29,7 +29,7 @@ Trước khi bắt đầu, bạn nên kiểm tra lỗi của thẻ nhớ SD bằ
 * Phiên bản mới nhất của [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * Phiên bản mới nhất của [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * Phiên bản mới nhất của [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* Phiên bản mới nhất của [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* Phiên bản mới nhất của [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * Phiên bản mới nhất của [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * Phiên bản mới nhất của [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * Phiên bản mới nhất của [Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/zh_CN/get-started.txt
+++ b/_pages/zh_CN/get-started.txt
@@ -28,7 +28,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*

--- a/_pages/zh_TW/get-started.txt
+++ b/_pages/zh_TW/get-started.txt
@@ -28,7 +28,7 @@ title: "新手入門"
 * 最新版的 [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
 * 最新版的 [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * 最新版的 [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
-* 最新版的 [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/)
+* 最新版的 [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
 * 最新版的 [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * 最新版的 [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * 最新版的 [Homebrew Launcher 頻道](https://github.com/dimok789/homebrew_launcher/releases/latest) *(選擇 channel `.zip` 檔案)*


### PR DESCRIPTION
…to avoid confusion with the plugin version.

A few weeks ago I started to also provide nightly versions of the [HIDtoVPAD plugin version](https://github.com/Maschell/hid_to_vpad/tree/wups) and I think people are getting confused and download the wrong version (It had ~4000 downloads, while the plugin loader only had 600). This version is only usable in combination with the loader of the [Wii U plugin system](https://github.com/Maschell/WiiUPluginSystem), which is currently NOT ready for the average user and still in very active (and compability breaking) developement.

I changed the URL to use the latest stable release (which currently is a non-plugin version), but maybe it makes sense to also add a little note for the users to **not** download the WUPS files (until WUPS is ready for mainstream)?