### PR TITLE
Update guide to include new browser exploit

### DIFF
--- a/_pages/en_US/get-started.txt
+++ b/_pages/en_US/get-started.txt
@@ -26,6 +26,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * [config.txt]({{ "/assets/files/config.txt" | absolute_url }}){:download="config.txt"}
 * [config.ini]({{ "/assets/files/config.ini" | absolute_url }}){:download="config.ini"}
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
+* The latest release of [Homebrew Launcher Installer](https://github.com/wiiu-env/homebrew_launcher_installer/releases/latest)
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
 * The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)
@@ -49,6 +50,7 @@ For all steps in this section, overwrite any existing files on your SD card.
 1. Create a folder named `wiiu` on the root of your SD card
 1. Create a folder named `install` on the root of your SD card
 1. Copy the `apps` folder from the Homebrew App Store `.zip` to the `/wiiu/` folder on your SD card
+1. Copy *the contents of* the payload `.zip` to the wiiu folder on your SD card
 1. Copy *the contents of* the Homebrew Launcher (v1.3) `.zip` to the root of your SD card
 1. Copy *the contents of* the Haxchi `.zip` to the root of your SD card
 1. Copy *the contents of* the CBHC `.zip` to the root of your SD card

--- a/_pages/en_US/homebrew-launcher.txt
+++ b/_pages/en_US/homebrew-launcher.txt
@@ -22,12 +22,9 @@ We launch this using the Wii U's built in browser, so your Wii U will need to be
 
 #### Section II - Homebrew Launcher
 
-1. If your device is on firmware versions 5.5.2 or 5.5.3, open the browser curtains
-  + This improves the success rate of the 5.5.2 / 5.5.3 browser exploit
-1. Go to `usploit.hacks.guide`
+1. Go to `wiiuexploit.xyz`
   + You may want to bookmark this address to save time on typing in the future
 1. Select "Run Homebrew Launcher" for the first exploit attempt
-  + This may take many tries
   + If it freezes, just force the console to power off by holding the power button, then try again
 1. Your console should load the Homebrew Launcher
 


### PR DESCRIPTION
->Changed link to wiiuexploit.xyz which uses the new exploit
-> Added link to payload.elf (needed for the new exploit)
-> Removed text saying that the browser exploit is unstable (new one seems to have 100% success rate)