### PR TITLE
Fix link to 1.4 homebrew launcher

### DIFF
--- a/_pages/en_US/get-started.txt
+++ b/_pages/en_US/get-started.txt
@@ -33,7 +33,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * The latest release of [Mocha CFW](https://www.wiiubru.com/appstore/zips/mocha.zip)
 * The latest release of [savemii_mod](https://github.com/GabyPCgeeK/savemii/releases)
 * The latest release of [the Homebrew Launcher Channel](https://github.com/dimok789/homebrew_launcher/releases/latest) *(the channel `.zip` file)*
-* A previous release (v1.4) of [the Homebrew Launcher](https://github.com/dimok789/homebrew_launcher/releases/tag/v1.4) *(the launcher `.zip` file)*
+* A previous release (v1.4) of [the Homebrew Launcher](https://github.com/dimok789/homebrew_launcher/releases/tag/1.4) *(the launcher `.zip` file)*
 * The latest release of [Wii U NAND Dumper](https://github.com/koolkdev/wiiu-nanddumper/releases/latest)
 * The latest release of [Haxchi and CBHC](https://github.com/FIX94/haxchi/releases/latest) *(both `.zip` files)*
 * The latest release of [NNU-Patcher](https://wiiubru.com/appstore/zips/nnupatcher.zip)


### PR DESCRIPTION
Link to the 1.4 homebrew launcher is broken in current guide. The link to version 1.4 doesn't have a "v" in front of its version number