### PR TITLE
Multiple corrections in the guide (and my previous PR)

### DIFF
--- a/_pages/en_US/coldboot-haxchi.txt
+++ b/_pages/en_US/coldboot-haxchi.txt
@@ -26,8 +26,6 @@ Your Haxchi DS virtual console game MUST be a LEGITIMATE (non-pirated) copy or y
 
 {% capture notice-1 %}
 This is an optional section which will create a backup of your device's internal NAND memory on your SD card, which will allow you to restore your device in the case of a brick.
-
-If you have a black Wii U (32GB) model, your SD card must be at least 64GB in size. If you have a white (8GB) Wii U model, your SD card must be at least 16GB in size.
 {% endcapture %}
 
 <div class="notice--info">{{ notice-1 | markdownify }}</div>
@@ -45,7 +43,7 @@ If you accept the risk of installing CBHC without a NAND backup, skip this secti
 1. Use the D-Pad to set the following options:
   + Dump SLC (528MB): **yes**
   + Dump SLCCMPT (528MB): **yes**
-  + Dump MLC (8GB/32GB): **yes**
+  + Dump MLC (8GB/32GB): **no**
   + Dump OTP (1KB): **yes**
   + Dump SEEPROM (1KB): **yes**
 1. Press (A) to dump your NAND
@@ -53,7 +51,7 @@ If you accept the risk of installing CBHC without a NAND backup, skip this secti
 1. When it has completed, your Wii U will reboot automatically
 1. Power off your device
 1. Insert your SD card into your computer
-1. Copy `slc.bin`, `slccmpt.bin`, `otp.bin`, `seeprom.bin`, and each `mlc.bin.part` file from the root of your SD card to a safe location on your computer
+1. Copy the `slc.bin`, `slccmpt.bin`, `otp.bin`, `seeprom.bin` files from the root of your SD card to a safe location on your computer
   + Make backups in multiple locations (such as online file storage)
   + These backups will save you from a brick and/or help you recover files from the NAND image if anything goes wrong in the future
 1. Reinsert your SD card into your device

--- a/_pages/en_US/faq.txt
+++ b/_pages/en_US/faq.txt
@@ -30,7 +30,7 @@ title: "FAQ"
 **A:** For support, ask for help at [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp).
 
 <a name="faq_sdsize" />**Q:** *How big of an SD card do I need?*    
-**A:** Your SD card must be at least 64GB in size if you have a black Wii U (32GB) model. If you have a white (8GB) Wii U model, your SD card needs to be at least 16GB in size.
+**A:** Your SD card is recommended to be at least 16GB or 32GB to have enough space for dumping and installing games. If you want to do a full NAND backup of a white (8GB) Wii U model, your SD card needs to be at least 16GB in size. If you want to do a full NAND backup of a black (32GB) Wii U model, your SD card needs to be at least 64GB in size.
 
 <a name="faq_NNID" />**Q:** *Can I keep my NNID?*    
 **A:** If you start with an NNID and follow every step, you will end up keeping your NNID at the end.

--- a/_pages/en_US/get-started.txt
+++ b/_pages/en_US/get-started.txt
@@ -26,7 +26,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 * [config.txt]({{ "/assets/files/config.txt" | absolute_url }}){:download="config.txt"}
 * [config.ini]({{ "/assets/files/config.ini" | absolute_url }}){:download="config.ini"}
 * The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
-* The latest release of [Homebrew Launcher Installer](https://github.com/wiiu-env/homebrew_launcher_installer/releases/latest)
+* The latest release of [Homebrew Launcher Installer](https://github.com/wiiu-env/homebrew_launcher_installer/releases/latest) *(the payload `.zip` file)*
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
 * The latest release of [hid\_to\_vpad](https://github.com/Maschell/hid_to_vpad/releases/latest)


### PR DESCRIPTION
-Updated information to disable "Dump MLC" in NAND Dumper as the MLC part isn't needed for unbricking.
-> Since the NAND Backup is relatively small in size without the MLC part, I removed the "You'll need a 64/16GB SD card"

-Changed the SD-size recommendations to say the same as the main page (with some additional information because of my change in the NAND Backup secion)

-I've seen a few people having trouble finding the payload.zip file, so I added additional information on which download includes the payload
