### PR TITLE
NAND Backup + CBHC changes

### DIFF
--- a/_data/navigation/en_US.yml
+++ b/_data/navigation/en_US.yml
@@ -55,6 +55,9 @@ sidebar_pages:
     title: Homebrew Launcher
     url: homebrew-launcher
   -
+    title: NAND Backup
+    url: nand-backup
+  -
     title: Multiple Options
     url: multiple-options
   -

--- a/_pages/en_US/coldboot-haxchi.txt
+++ b/_pages/en_US/coldboot-haxchi.txt
@@ -8,7 +8,7 @@ title: "Coldboot Haxchi"
 
 CBHC (Coldboot Haxchi) changes your default system title from the system menu to your DS virtual console game. This causes your device to launch CFW automatically at boot.
 
-This exploit is slightly more dangerous than standard Haxchi because your DS Virtual Console game exploit is the *only* way to boot the system. If this game is ever deleted or the exploit is removed, installing CBHC will BRICK your device!
+This exploit is slightly more dangerous than standard Haxchi because your DS Virtual Console game exploit is the *only* way to boot the system. If this game is ever deleted or moved to USB storage while CBHC is installed, you will BRICK!
 
 {% capture notice-1 %}
 You MUST have a functional Haxchi setup for this to work. If you do not, you will BRICK!
@@ -16,50 +16,13 @@ You MUST have a functional Haxchi setup for this to work. If you do not, you wil
 Your Haxchi DS virtual console game MUST be on the internal memory of your Wii U. If it is on a USB drive, you will BRICK!
 
 Your Haxchi DS virtual console game MUST be a LEGITIMATE (non-pirated) copy or you will BRICK!
+
+It is not possible to brick your device by installing CBHC as long as *all instructions and warnings are followed*.
 {% endcapture %}
 
 <div class="notice--danger">{{ notice-1 | markdownify }}</div>
 
 ### Instructions
-
-#### Section I - NAND Backup
-
-{% capture notice-1 %}
-This is an optional section which will create a backup of your device's internal NAND memory on your SD card, which will allow you to restore your device in the case of a brick.
-
-If you have a black Wii U (32GB) model, your SD card must be at least 64GB in size. If you have a white (8GB) Wii U model, your SD card must be at least 16GB in size.
-{% endcapture %}
-
-<div class="notice--info">{{ notice-1 | markdownify }}</div>
-
-{% capture notice-1 %}
-It is not possible to brick your device by installing CBHC as long as *all instructions and warnings are followed*. This, combined with the strict SD card requirements and extremely slow NAND dumping speed, means that creating a NAND backup is currently an optional step
-
-If you accept the risk of installing CBHC without a NAND backup, skip this section.
-{% endcapture %}
-
-<div class="notice--info">{{ notice-1 | markdownify }}</div>
-
-1. Enter the Homebrew Launcher by holding (A) while launching your Haxchi DS virtual console game
-1. Launch nanddumper
-1. Use the D-Pad to set the following options:
-  + Dump SLC (528MB): **yes**
-  + Dump SLCCMPT (528MB): **yes**
-  + Dump MLC (8GB/32GB): **yes**
-  + Dump OTP (1KB): **yes**
-  + Dump SEEPROM (1KB): **yes**
-1. Press (A) to dump your NAND
-  + Be prepared to wait; this can take a while (up to several hours depending on how much used space you have on the internal memory)
-1. When it has completed, your Wii U will reboot automatically
-1. Power off your device
-1. Insert your SD card into your computer
-1. Copy `slc.bin`, `slccmpt.bin`, `otp.bin`, `seeprom.bin`, and each `mlc.bin.part` file from the root of your SD card to a safe location on your computer
-  + Make backups in multiple locations (such as online file storage)
-  + These backups will save you from a brick and/or help you recover files from the NAND image if anything goes wrong in the future
-1. Reinsert your SD card into your device
-1. Power on your device
-
-#### Section II - Installing CBHC
 
 1. Remove all USB devices from your Wii U
 1. Enter the Homebrew Launcher by holding (A) while launching your Haxchi DS virtual console game

--- a/_pages/en_US/coldboot-haxchi.txt
+++ b/_pages/en_US/coldboot-haxchi.txt
@@ -16,8 +16,6 @@ You MUST have a functional Haxchi setup for this to work. If you do not, you wil
 Your Haxchi DS virtual console game MUST be on the internal memory of your Wii U. If it is on a USB drive, you will BRICK!
 
 Your Haxchi DS virtual console game MUST be a LEGITIMATE (non-pirated) copy or you will BRICK!
-
-It is not possible to brick your device by installing CBHC as long as *all instructions and warnings are followed*.
 {% endcapture %}
 
 <div class="notice--danger">{{ notice-1 | markdownify }}</div>

--- a/_pages/en_US/homebrew-launcher.txt
+++ b/_pages/en_US/homebrew-launcher.txt
@@ -19,24 +19,6 @@ We launch this using the Wii U's built in browser, so your Wii U will need to be
 1. Your console should load the Homebrew Launcher
 
 ___
-### Methods
 
-___
-
-#### Mocha CFW
-
-This method requires that you rerun the web exploit used above *after every reboot*.
-
-### Continue to [Mocha CFW](mocha-cfw)
+### Continue to [Creating a NAND backup](nand-backup)
 {: .notice--primary}
-
-___
-
-#### Haxchi
-
-This method uses a cheap exploitable DS Virtual Console game to launch your Custom Firmware automatically at boot.
-
-### Continue to [Haxchi](haxchi)
-{: .notice--primary}
-
-___

--- a/_pages/en_US/nand-backup.txt
+++ b/_pages/en_US/nand-backup.txt
@@ -18,8 +18,6 @@ If you want a full backup including MLC, and have a black Wii U (32GB) model, yo
 
 <div class="notice--info">{{ notice-1 | markdownify }}</div>
 
-<div class="notice--info">{{ notice-1 | markdownify }}</div>
-
 1. Enter the Homebrew Launcher by holding (A) while launching your Haxchi DS virtual console game
 1. Launch nanddumper
 1. Use the D-Pad to set the following options:

--- a/_pages/en_US/nand-backup.txt
+++ b/_pages/en_US/nand-backup.txt
@@ -1,0 +1,61 @@
+---
+title: "NAND Backup"
+---
+
+{% include toc title="Table of Contents" %}
+
+### Required Reading
+
+This section will create a backup of your device's internal NAND memory on your SD card, which will allow you to restore your device via a hardmod in the case of a brick.
+
+### Instructions
+
+{% capture notice-1 %}
+A backup of the MLC partition is optional as it's huge in size, and most bricks that need MLC to be restored are done by user-error.
+
+If you want a full backup including MLC, and have a black Wii U (32GB) model, your SD card must be at least 64GB in size. If you have a white (8GB) Wii U model, your SD card must be at least 16GB in size.
+{% endcapture %}
+
+<div class="notice--info">{{ notice-1 | markdownify }}</div>
+
+<div class="notice--info">{{ notice-1 | markdownify }}</div>
+
+1. Enter the Homebrew Launcher by holding (A) while launching your Haxchi DS virtual console game
+1. Launch nanddumper
+1. Use the D-Pad to set the following options:
+  + Dump SLC (528MB): **yes**
+  + Dump SLCCMPT (528MB): **yes**
+  + Dump MLC (8GB/32GB): **optional**
+  + Dump OTP (1KB): **yes**
+  + Dump SEEPROM (1KB): **yes**
+1. Press (A) to dump your NAND
+  + Be prepared to wait; this can take a while (up to several hours depending on the options you enabled)
+1. When it has completed, your Wii U will reboot automatically
+1. Power off your device
+1. Insert your SD card into your computer
+1. Copy `slc.bin`, `slccmpt.bin`, `otp.bin`, and `seeprom.bin`, and each `mlc.bin.part` file (if you chose to backup the MLC partition) from the root of your SD card to a safe location on your computer
+  + Make backups in multiple locations (such as online file storage)
+  + These backups will save you from a brick and/or help you recover files from the NAND image if anything goes wrong in the future
+1. Reinsert your SD card into your device
+1. Power on your device
+
+___
+### Methods
+
+___
+
+#### Mocha CFW
+
+This method requires that you rerun the web exploit used above *after every reboot*.
+
+### Continue to [Mocha CFW](mocha-cfw)
+{: .notice--primary}
+
+___
+
+#### Haxchi
+
+This method uses a cheap exploitable DS Virtual Console game to launch your Custom Firmware automatically at boot.
+
+### Continue to [Haxchi](haxchi)
+{: .notice--primary}

--- a/_pages/en_US/site-navigation.txt
+++ b/_pages/en_US/site-navigation.txt
@@ -21,6 +21,7 @@ sitemap: false
 + [Homebrew Launcher (Channel)](homebrew-launcher-(channel))
 + [Homebrew Launcher](homebrew-launcher)
 + [Mocha CFW](mocha-cfw)
++ [NAND Backup](nand-backup)
 + [Uninstall Mocha CFW](uninstall-cfw)
 + [vWii Modding](vwii-modding)
 + [Why Ads?](why-ads)


### PR DESCRIPTION
-navigation changed to include NAND Backup page 
 (even tho that's not working and the "Current 
 Progress" sidebar doesn't appear in that section)
-cbhc.txt changed to have nand backup instructions 
 removed
-nand-backup.txt as new nand-backup page got 
 added (after homebrew-launcher and before 
 "multiple options" pages)
-homebrew_launcher.txt changed to continue to 
 nand-backup.txt instead of "multiple options"
-site-navigation.txt got the nand-backup.txt added

I hope this all is fine. I still hate Githubs PR implementation