### PR TITLE
Change instructions for the appstore

### DIFF
--- a/_pages/en_US/get-started.txt
+++ b/_pages/en_US/get-started.txt
@@ -25,7 +25,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 
 * [config.txt]({{ "/assets/files/config.txt" | absolute_url }}){:download="config.txt"}
 * [config.ini]({{ "/assets/files/config.ini" | absolute_url }}){:download="config.ini"}
-* The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest)
+* The latest release of [Homebrew App Store](https://github.com/vgmoose/hbas/releases/latest) *(the wiiu-extracttosd `.zip` file)*
 * The latest release of [Homebrew Launcher Installer](https://github.com/wiiu-env/homebrew_launcher_installer/releases/latest) *(the payload `.zip` file)*
 * The latest release of [WUP Installer GX2](http://wiiubru.com/appstore/zips/wup_installer_gx2.zip)
 * The latest release of [disc2app](https://github.com/koolkdev/disc2app/releases/latest)
@@ -49,7 +49,7 @@ For all steps in this section, overwrite any existing files on your SD card.
 1. Insert your SD card into your computer
 1. Create a folder named `wiiu` on the root of your SD card
 1. Create a folder named `install` on the root of your SD card
-1. Copy the `apps` folder from the Homebrew App Store `.zip` to the `/wiiu/` folder on your SD card
+1. Copy *the contents of* the wiiu-extracttosd `.zip` to the root of your SD card
 1. Copy *the contents of* the payload `.zip` to the wiiu folder on your SD card
 1. Copy *the contents of* the Homebrew Launcher (v1.4) `.zip` to the root of your SD card
 1. Copy *the contents of* the Haxchi `.zip` to the root of your SD card


### PR DESCRIPTION
The new appstore uses a different file structure + a different file name, so just extracting the contents of it to the SD works now. Also added a note to mention the name of the correct .zip file as some people get confused by which one to download.