### PR TITLE
Add a step specifying how to use Dump Mii NAND

### DIFF
--- a/_pages/en_US/vwii-modding.txt
+++ b/_pages/en_US/vwii-modding.txt
@@ -60,6 +60,7 @@ This NAND backup will allow you to restore your vWii to a working state if anyth
 
 1. Launch the Homebrew Channel on vWii
 1. Launch Dump Mii NAND
+1. Select "Load"
   + Be prepared to wait; this can take a while (up to several hours depending on the speed of your SD card)
 1. When it has completed, your Wii U will reboot automatically
 1. Power off your Wii U


### PR DESCRIPTION
This is the first time in the process that an app is launched. Having clicked on the app name, I assumed that the app was already running, so was confused to see buttons "Delete" and "Load". The first time round it's not obvious that this is just the launcher's menu, so it wasn't obvious what these buttons do! Would be good to make this step explicit. Thanks.